### PR TITLE
Feature: Add syntax highlighting

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
   <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:400,600" rel="stylesheet" type="text/css">
   <link href="https://fonts.googleapis.com/css?family=Lora:400,400italic,700" rel="stylesheet" type="text/css">
   <link href="https://fonts.googleapis.com/css?family=Open+Sans:800,700,400" rel="stylesheet" type="text/css">
-  <!-- Syntax highlighting -->
+  <!-- Syntax highlighting theme -->
   <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.4.1/themes/prism-solarizedlight.min.css" rel="stylesheet" type="text/css">
 </head>
 <body>
@@ -18,9 +18,5 @@
     <p style="text-align: center;">Oops! Something is broken or JavaScript is not enabled.</p>
   </div>
   <script async defer type="text/javascript" src="main.js"></script>
-  <!-- Syntax highlighting -->
-  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.4.1/prism.min.js"></script>
-  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.4.1/components/prism-javascript.min.js"></script>
-  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.4.1/components/prism-jsx.min.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -6,14 +6,21 @@
   <title>Spectacle</title>
   <meta name="description" content="">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+  <!-- Fonts -->
   <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:400,600" rel="stylesheet" type="text/css">
   <link href="https://fonts.googleapis.com/css?family=Lora:400,400italic,700" rel="stylesheet" type="text/css">
   <link href="https://fonts.googleapis.com/css?family=Open+Sans:800,700,400" rel="stylesheet" type="text/css">
+  <!-- Syntax highlighting -->
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.4.1/themes/prism-solarizedlight.min.css" rel="stylesheet" type="text/css">
 </head>
 <body>
   <div id="content">
     <p style="text-align: center;">Oops! Something is broken or JavaScript is not enabled.</p>
   </div>
   <script async defer type="text/javascript" src="main.js"></script>
+  <!-- Syntax highlighting -->
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.4.1/prism.min.js"></script>
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.4.1/components/prism-javascript.min.js"></script>
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.4.1/components/prism-jsx.min.js"></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Documentation site for Spectacle",
   "main": "webpack.config.dev.js",
   "scripts": {
+    "start": "npm run dev",
     "dev": "webpack-dev-server --port 3000 --config webpack.config.dev.js",
     "lint-react": "eslint src/**/*.js src/**/*.jsx",
     "lint-node": "eslint --config .eslint-node ./*.js",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "handlebars-loader": "^1.1.4",
     "image-webpack-loader": "^1.6.3",
     "marked": "^0.3.5",
+    "prismjs": "^1.4.1",
     "radium": "^0.16.2",
     "raw-loader": "0.5.1",
     "react": "^0.14.5",

--- a/src/components/docs.jsx
+++ b/src/components/docs.jsx
@@ -1,7 +1,13 @@
 import React from "react";
 import Radium from "radium";
 import marked from "marked";
+import Prism from "prismjs";
+/* eslint-disable no-unused-vars */
+// adds support for language-jsx (Prism.languages.jsx)
+import jsx from "prismjs/components/prism-jsx";
+/* eslint-enable no-unused-vars */
 
+// Variables
 import settings from "../spectacle-variables";
 import SpectacleREADME from "!!raw!spectacle/README.markdown";
 
@@ -52,6 +58,11 @@ class Docs extends React.Component {
       }
     };
   }
+
+  componentDidMount() {
+    Prism.highlightAll();
+  }
+
   render() {
     const spectacleDocs = marked(SpectacleREADME);
     const videoStyles = this.getVideoStyles();
@@ -70,8 +81,8 @@ class Docs extends React.Component {
             </iframe>
           </div>
         </div>
-       <div className="Docs" dangerouslySetInnerHTML={{__html: spectacleDocs}}>
-       </div>
+         <div className="Docs" ref="code" dangerouslySetInnerHTML={{__html: spectacleDocs}}>
+         </div>
       </section>
     );
   }

--- a/src/spectacle-theme.js
+++ b/src/spectacle-theme.js
@@ -71,7 +71,7 @@ export default {
   },
   th: {
     color: settings.text,
-    borderBottom: `3px solid ${settings.codeBg}`,
+    borderBottom: `3px solid ${settings.brownTint}`,
     fontWeight: 700,
     textAlign: "left"
   },
@@ -262,6 +262,7 @@ export default {
   },
   ".Docs code, .Focus code, td code, th code": {
     background: settings.codeBg,
+    border: `1px solid ${settings.codeBg}`,
     color: settings.text,
     fontFamily: settings.monospace,
     fontSize: "0.925em",
@@ -277,11 +278,12 @@ export default {
    * Ecology text wrangling
    */
   ".Docs pre": {
-    background: settings.codeBg,
-    padding: "0.25em 0.5em",
+    background: settings.whiteCodeBg,
+    padding: "1em 0.5em",
     overflowX: "scroll" // bring back scrollbars for readme.md
   },
   ".Docs pre code": {
+    border: "none",
     background: "none"
   },
   /*

--- a/src/spectacle-variables.js
+++ b/src/spectacle-variables.js
@@ -20,8 +20,9 @@ module.exports = {
   red: "#912A18",
   brown: "#291C0D", // rgb(41, 28, 13)
   brownTint: "rgba(41, 28, 13, 0.1)",
-  codeBg: "rgba(234, 181, 70, 0.25)",
-  lightCodeBg: "rgba(234, 181, 70, 0.1)",
+  codeBg: "rgba(234,210,108, 0.25)",
+  lightCodeBg: "rgba(253, 246, 227, 0.25)",
+  whiteCodeBg: "rgba(253, 246, 227, 0.5)",
 
   // Formidable Reds
   brandRed: "#bd1e13",


### PR DESCRIPTION
- Add [prism.js](http://prismjs.com/) syntax highlighting for JavaScript and JSX
- Update colors so the theme looks okay
- [x] This will require the spectacle README.md to use three backticks with jsx instead of javascript, see https://github.com/FormidableLabs/spectacle/pull/161

/cc @coopy @tptee 

screenshot: 
![screen shot 2016-03-04 at 11 41 32 am](https://cloud.githubusercontent.com/assets/768965/13538277/647bc952-e1fe-11e5-8dd4-f79847a0b3c1.png)