### PR TITLE
Upgrade builder-docs-archetype

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "spectacle-docs",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "description": "Documentation site for Spectacle",
   "main": "webpack.config.dev.js",
   "scripts": {
     "start": "builder run dev",
-    "test": "builder run lint"
+    "test": "builder run lint",
+    "update-project": "npm update spectacle"
   },
   "repository": {
     "type": "git",
@@ -18,11 +19,11 @@
   },
   "homepage": "https://github.com/FormidableLabs/spectacle-docs#readme",
   "devDependencies": {
-    "builder-docs-archetype-dev": "^0.0.4"
+    "builder-docs-archetype-dev": "^1.0.5"
   },
   "dependencies": {
     "builder": "^2.9.1",
-    "builder-docs-archetype": "^0.0.4",
+    "builder-docs-archetype": "^1.0.5",
     "formidable-landers": "^1.1.0",
     "marked": "^0.3.5",
     "prismjs": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "builder": "^2.9.1",
     "builder-docs-archetype": "^1.0.5",
-    "formidable-landers": "^1.1.0",
+    "formidable-landers": "^3.0.0",
     "marked": "^0.3.5",
     "prismjs": "^1.4.1",
     "radium": "^0.17.1",

--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -20,7 +20,7 @@ class App extends React.Component {
   getHeaderStyles() {
     return {
       overrides: {
-        backgroundColor: "transparent",
+        background: "transparent",
         borderTop: `1em solid ${settings.text}`,
         borderRight: `1em solid ${settings.text}`,
         borderBottom: "0",
@@ -96,7 +96,7 @@ class App extends React.Component {
         <Docs />
         <Footer
           logoColor="black"
-          backgroundColor={"transparent"}
+          background="transparent"
           styleOverrides={footerStyles.overrides}
           linkStyles={footerStyles.linkStyles}
         />

--- a/src/components/static-entry.jsx
+++ b/src/components/static-entry.jsx
@@ -5,8 +5,11 @@ import { renderToString } from "react-dom/server";
 import App from "./app";
 import Index from "../../templates/index.hbs";
 
-// Run once we hit the client side
-if (typeof document !== "undefined") {
+// Client render (optional):
+// `static-site-generator-webpack-plugin` supports shimming browser globals
+// so instead of checking whether the document is undefined (always false),
+// Check whether it’s being shimmed
+if (typeof window !== "undefined" && window.__STATIC_GENERATOR !== true) { //eslint-disable-line no-undef
   render(<App />, document.getElementById("content"));
 }
 

--- a/static/logotype-spectacle.svg
+++ b/static/logotype-spectacle.svg
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
 <svg version="1.1" x="0px" y="0px"
-	 viewBox="0 0 800 175" style="enable-background:new 0 0 800 175;max-width:100%;height:auto;" xml:space="preserve" role="img">
+	 viewBox="0 0 800 175" style="enable-background:new 0 0 800 175;max-width:100%;height:auto;" xmlSpace="preserve" role="img">
 	 <title>Spectacle</title>
 <g id="spectacle-logotype">
 	<g>


### PR DESCRIPTION
- Upgrade `builder-docs-archetype` and `formidable-landers`
- Update static-entry to support shimming global variables
- Use `background` instead of `backgroundColor`, following the `formidable-landers` upgrade