### PR TITLE
Bug: In production, append trailing slash to generate TOC 

### DIFF
--- a/src/components/sidebar.js
+++ b/src/components/sidebar.js
@@ -70,6 +70,10 @@ class Sidebar extends React.Component {
   }
 
   renderToc(targetLocation) {
+    if (targetLocation[targetLocation.length - 1] !== "/" && process.env.NODE_ENV === "production") {
+      targetLocation = `${targetLocation}/`;
+    }
+
     if (!this.props.location || (this.props.location.pathname !== targetLocation)) {
       return null;
     }


### PR DESCRIPTION
There's an issue where hitting `/docs` will not show the table of contents, but `/docs/` would. This PR (should) check if there is a trailing slash in production, and if not, add a trailing slash. 

/cc @rawrmonstar 