### PR TITLE
Fix getting-started link active class

### DIFF
--- a/src/components/sidebar.js
+++ b/src/components/sidebar.js
@@ -72,10 +72,16 @@ class Sidebar extends React.Component {
 
   renderToc(targetLocation) {
     let pathname = this.props.location && locationHelper(this.props.location.pathname);
-    pathname = pathname === locationHelper("/docs")
-      ? locationHelper("/docs/getting-started")
-      : pathname;
+    const gettingStartedLocation = locationHelper("/docs/getting-started");
+    const docsLocation = locationHelper("/docs");
     targetLocation = locationHelper(targetLocation);
+
+    pathname = pathname === docsLocation
+      ? gettingStartedLocation
+      : pathname;
+    targetLocation = targetLocation === docsLocation
+      ? gettingStartedLocation
+      : targetLocation;
 
     if (!pathname || (pathname !== targetLocation)) {
       return null;
@@ -90,6 +96,10 @@ class Sidebar extends React.Component {
   }
 
   render() {
+    // getting-started link should be active when at /docs in addition to /docs/getting-started
+    const pathname = this.props.location && locationHelper(this.props.location.pathname);
+    const gettingStartedClass = pathname === locationHelper("/docs") ? "is-active" : "";
+
     return (
       <nav className="Sidebar">
         <p className="Subheading u-noMargin">
@@ -98,7 +108,7 @@ class Sidebar extends React.Component {
         <div className="u-noMarginTop Grid Grid--gutters Grid--1of3--flex large-Grid--column">
           <div className="Grid-cell u-noMarginTop">
             <Link to="/docs/getting-started"
-              className="btn btn--dark u-displayBlock u-nowrap" activeClassName="is-active"
+              className={`btn btn--dark u-displayBlock u-nowrap ${gettingStartedClass}`} activeClassName="is-active"
             >
               Let’s Get Started
             </Link>


### PR DESCRIPTION
The `getting-started` sidebar link isn't set to active after navigating to the docs using the docs link in the header, for example: 
![image](https://cloud.githubusercontent.com/assets/13814048/19531693/6ab619aa-95ed-11e6-96f2-9e563b9fce0d.png)

It should look like this:
![image](https://cloud.githubusercontent.com/assets/13814048/19531784/d3d7e508-95ed-11e6-9a1a-e13f63985b6d.png)

This is because the header link is to `docs` instead of `docs/getting-started`.  There is logic to render the `getting-started` TOC and markdown when at `docs` but there isn't any to set the link to active.

This manually sets the `is-active` class on the `getting-started` link when at `/docs`

/cc @paulathevalley 