### PR TITLE
Bug: Fix anchor link behavior

### DIFF
--- a/src/components/app.js
+++ b/src/components/app.js
@@ -26,8 +26,8 @@ class App extends React.Component {
           theme="dark"
         >
           <div className="default">
-            <Link to="/about" activeClassName="is-active">About</Link>
-            <Link to="/docs" activeClassName="is-active">Docs</Link>
+            <Link to="/about/" activeClassName="is-active">About</Link>
+            <Link to="/docs/" activeClassName="is-active">Docs</Link>
             <a href="https://www.github.com/FormidableLabs/spectacle/issues">Issues</a>
             <a href="https://github.com/FormidableLabs/spectacle">GitHub</a>
           </div>

--- a/src/components/entry.js
+++ b/src/components/entry.js
@@ -37,7 +37,11 @@ if (typeof window !== "undefined" && window.__STATIC_GENERATOR !== true) { //esl
     <Router
       history={history}
       routes={routes}
-      render={applyRouterMiddleware(useScroll())}
+      render={applyRouterMiddleware(
+        useScroll((prevRouterProps, { location }) => (
+          prevRouterProps && location.pathname !== prevRouterProps.location.pathname
+        ))
+      )}
     />,
     document.getElementById("content")
   );

--- a/src/components/sidebar.js
+++ b/src/components/sidebar.js
@@ -22,11 +22,10 @@ class Sidebar extends React.Component {
 
             return sibling && (
               <li key={id} className="Sidebar-toc-item">
-                <a
-                  href={`${basename}${targetLocation}#${sibling.anchor}`}
+                <Link
+                  to={`${basename}${targetLocation}#${sibling.anchor}`}
                   dangerouslySetInnerHTML={{__html: md.renderInline(sibling.content)}}
-                >
-                </a>
+                />
               </li>
             );
           })

--- a/src/components/sidebar.js
+++ b/src/components/sidebar.js
@@ -3,7 +3,6 @@ import { Link } from "react-router";
 import basename from "../basename";
 import MarkdownIt from "markdown-it";
 import { times } from "lodash";
-import locationHelper from "../helpers/location-helper";
 
 class Sidebar extends React.Component {
   renderTransformedToc(siblings, targetLocation) {
@@ -71,13 +70,7 @@ class Sidebar extends React.Component {
   }
 
   renderToc(targetLocation) {
-    let pathname = this.props.location && locationHelper(this.props.location.pathname);
-    pathname = pathname === locationHelper("/docs")
-      ? locationHelper("/docs/getting-started")
-      : pathname;
-    targetLocation = locationHelper(targetLocation);
-
-    if (!pathname || (pathname !== targetLocation)) {
+    if (!this.props.location || (this.props.location.pathname !== targetLocation)) {
       return null;
     }
 
@@ -90,6 +83,9 @@ class Sidebar extends React.Component {
   }
 
   render() {
+    const currentPath = this.props.location && this.props.location.pathname;
+    const gettingStartedClass = currentPath === "/docs/" ? "btn btn--dark u-displayBlock u-nowrap is-active" : "btn btn--dark u-displayBlock u-nowrap";
+
     return (
       <nav className="Sidebar">
         <p className="Subheading u-noMargin">
@@ -97,44 +93,45 @@ class Sidebar extends React.Component {
         </p>
         <div className="u-noMarginTop Grid Grid--gutters Grid--1of3--flex large-Grid--column">
           <div className="Grid-cell u-noMarginTop">
-            <Link to="/docs/getting-started"
-              className="btn btn--dark u-displayBlock u-nowrap" activeClassName="is-active"
+            <Link to="/docs/getting-started/"
+              className={gettingStartedClass} activeClassName="is-active"
             >
               Get Started
             </Link>
-            {this.renderToc("/docs/getting-started")}
+            {this.renderToc("/docs/getting-started/")}
+            {this.renderToc("/docs/")}
           </div>
           <div className="Grid-cell u-noMarginTop">
-            <Link to="/docs/basic-concepts"
+            <Link to="/docs/basic-concepts/"
               className="btn btn--dark u-displayBlock u-nowrap" activeClassName="is-active"
             >
               Basic Concepts
             </Link>
-            {this.renderToc("/docs/basic-concepts")}
+            {this.renderToc("/docs/basic-concepts/")}
           </div>
           <div className="Grid-cell u-noMarginTop">
-            <Link to="/docs/tag-api"
+            <Link to="/docs/tag-api/"
               className="btn btn--dark u-displayBlock u-nowrap" activeClassName="is-active"
             >
               Tag API
             </Link>
-            {this.renderToc("/docs/tag-api")}
+            {this.renderToc("/docs/tag-api/")}
           </div>
           <div className="Grid-cell u-noMarginTop">
-            <Link to="/docs/props"
+            <Link to="/docs/props/"
               className="btn btn--dark u-displayBlock u-nowrap" activeClassName="is-active"
             >
               Props
             </Link>
-            {this.renderToc("/docs/props")}
+            {this.renderToc("/docs/props/")}
           </div>
           <div className="Grid-cell u-noMarginTop">
-            <Link to="/docs/extensions"
+            <Link to="/docs/extensions/"
               className="btn btn--dark u-displayBlock u-nowrap" activeClassName="is-active"
             >
               Extensions
             </Link>
-            {this.renderToc("/docs/extensions")}
+            {this.renderToc("/docs/extensions/")}
           </div>
         </div>
       </nav>

--- a/src/helpers/location-helper.js
+++ b/src/helpers/location-helper.js
@@ -1,5 +1,0 @@
-export default (location) => {
-  return location[location.length - 1] !== "/" && process.env.NODE_ENV === "production"
-    ? `${location}/`
-    : location;
-};

--- a/src/routes.js
+++ b/src/routes.js
@@ -10,8 +10,8 @@ import Docs from "./screens/docs/index";
 module.exports = (
   <Route path="/" component={App}>
     <IndexRoute component={Home}/>
-    <Route path="/docs" component={Docs}/>
-    <Route path="/docs/:component" component={Docs}/>
-    <Route path="/about" component={About}/>
+    <Route path="/docs/" component={Docs}/>
+    <Route path="/docs/:component/" component={Docs}/>
+    <Route path="/about/" component={About}/>
   </Route>
 );

--- a/src/screens/docs/components/markdown.js
+++ b/src/screens/docs/components/markdown.js
@@ -27,7 +27,7 @@ class Markdown extends React.Component {
   componentDidMount() {
     Prism.highlightAll();
     if (this.refs.html) {
-      this.refs.html.addEventListener("click", this.onNodeClick);
+      this.refs.html.addEventListener("click", this.onNodeClick.bind(this));
     }
   }
 
@@ -38,11 +38,11 @@ class Markdown extends React.Component {
   componentWillMount() {
     this.renderMd(this.props);
     if (this.refs.html) {
-      this.refs.html.removeEventListener("click", this.onNodeClick);
+      this.refs.html.removeEventListener("click", this.onNodeClick.bind(this));
     }
   }
 
-  onNodeClick = (e) => {
+  onNodeClick(e) {
     const node = e.target;
 
     // Only accept links

--- a/src/screens/docs/components/markdown.js
+++ b/src/screens/docs/components/markdown.js
@@ -1,5 +1,6 @@
 import React from "react";
 import find from "lodash/find";
+import { withRouter } from "react-router";
 
 import MarkdownIt from "markdown-it";
 import markdownItTocAndAnchor from "markdown-it-toc-and-anchor";
@@ -25,6 +26,9 @@ class Markdown extends React.Component {
 
   componentDidMount() {
     Prism.highlightAll();
+    if (this.refs.html) {
+      this.refs.html.addEventListener("click", this.onNodeClick);
+    }
   }
 
   componentDidUpdate() { // is this the right one??
@@ -33,6 +37,31 @@ class Markdown extends React.Component {
 
   componentWillMount() {
     this.renderMd(this.props);
+    if (this.refs.html) {
+      this.refs.html.removeEventListener("click", this.onNodeClick);
+    }
+  }
+
+  onNodeClick = (e) => {
+    const node = e.target;
+
+    // Only accept links
+    if (node.tagName !== "A") {
+      return;
+    }
+
+    const href = node.getAttribute("href");
+
+    // that point to an internal page
+    if (href.indexOf("/") !== 0) {
+      return;
+    }
+
+    // Prevent browser default
+    e.preventDefault();
+
+    // let react router handle the transition
+    this.props.router.push(href);
   }
 
   componentWillReceiveProps(newProps) {
@@ -93,6 +122,7 @@ class Markdown extends React.Component {
   render() {
     return (
       <article
+        ref="html"
         className="Markdown"
         dangerouslySetInnerHTML={{
           __html: this.state.renderedMd
@@ -105,11 +135,12 @@ class Markdown extends React.Component {
 Markdown.propTypes = {
   location: React.PropTypes.object.isRequired,
   params: React.PropTypes.object,
-  updateTocArray: React.PropTypes.func.isRequired
+  updateTocArray: React.PropTypes.func.isRequired,
+  router: React.PropTypes.object
 };
 
 Markdown.defaultProps = {
   params: null
 };
 
-export default Markdown;
+export default withRouter(Markdown);

--- a/src/screens/docs/components/markdown.js
+++ b/src/screens/docs/components/markdown.js
@@ -19,6 +19,7 @@ import { config } from "../../../components/config";
 class Markdown extends React.Component {
   constructor() {
     super();
+    this.onNodeClick = this.onNodeClick.bind(this);
     this.state = {
       renderedMd: ""
     };
@@ -27,7 +28,7 @@ class Markdown extends React.Component {
   componentDidMount() {
     Prism.highlightAll();
     if (this.refs.html) {
-      this.refs.html.addEventListener("click", this.onNodeClick.bind(this));
+      this.refs.html.addEventListener("click", this.onNodeClick);
     }
   }
 
@@ -38,7 +39,7 @@ class Markdown extends React.Component {
   componentWillMount() {
     this.renderMd(this.props);
     if (this.refs.html) {
-      this.refs.html.removeEventListener("click", this.onNodeClick.bind(this));
+      this.refs.html.removeEventListener("click", this.onNodeClick);
     }
   }
 

--- a/src/screens/docs/components/markdown.js
+++ b/src/screens/docs/components/markdown.js
@@ -13,7 +13,6 @@ import yaml from "prismjs/components/prism-yaml";
 
 import basename from "../../../basename";
 import { config } from "../../../components/config";
-import locationHelper from "../../../helpers/location-helper";
 
 
 class Markdown extends React.Component {
@@ -81,7 +80,7 @@ class Markdown extends React.Component {
       if (anchor && anchor.length > 0) {
         const href = anchor[1];
         if (href.indexOf("#") === 0) {
-          tokens[idx].attrs[1][1] = `${locationHelper(`${basename}${currentPath}`)}${href}`;
+          tokens[idx].attrs[1][1] = `${basename}${currentPath}${href}`;
           tokens[idx].attrs.push(["aria-hidden", "true"]);
         }
       }

--- a/src/screens/docs/index.js
+++ b/src/screens/docs/index.js
@@ -1,7 +1,5 @@
 import React from "react";
 
-import Radium from "radium";
-
 import Page from "../../components/page";
 import TitleMeta from "../../components/title-meta";
 import Markdown from "./components/markdown";
@@ -46,6 +44,4 @@ Docs.defaultProps = {
   params: null
 };
 
-const DocsComponent = Radium(Docs);
-
-export default DocsComponent;
+export default Docs;

--- a/src/screens/home/index.js
+++ b/src/screens/home/index.js
@@ -26,7 +26,7 @@ class Home extends React.Component {
 
         <div className="Grid Grid--gutters">
           <p className="Grid-cell Grid-cell--autoSize">
-            <Link className="btn btn--dark u-nowrap" to="/docs">
+            <Link className="btn btn--dark u-nowrap" to="/docs/">
               Get Started with Spectacle
             </Link>
           </p>

--- a/static-routes.js
+++ b/static-routes.js
@@ -2,12 +2,12 @@
 
 module.exports = [
   "/",
-  "/about",
-  "/docs",
-  "/docs/getting-started",
-  "/docs/basic-concepts",
-  "/docs/tag-api",
-  "/docs/props",
-  "/docs/extensions",
-  "/about"
+  "/about/",
+  "/docs/",
+  "/docs/getting-started/",
+  "/docs/basic-concepts/",
+  "/docs/tag-api/",
+  "/docs/props/",
+  "/docs/extensions/",
+  "/about/"
 ];


### PR DESCRIPTION
This PR
- Add trailing slashes to the routes, so dev matches production 
- Makes sure TOC renders for `/docs/` route and that the Getting Started button is in its active state 
- Do not scroll to the top of the page if clicking a hash link. I suspect there was some weirdness between both `useScroll()` and `anchorate()`, so this seems to be resolved now. 