### PR TITLE
Bug: Add muted to video to support autoplay

### DIFF
--- a/src/screens/home/index.js
+++ b/src/screens/home/index.js
@@ -10,7 +10,7 @@ class Home extends React.Component {
     return (
       <TitleMeta title="Spectacle">
         <div className="Hero">
-          <video className="Hero-video" width="100%" autoPlay loop poster="./static/bg-still.png">
+          <video className="Hero-video" width="100%" autoPlay muted loop poster="./static/bg-still.png">
             <source src="./static/bg-demo.webm" type="video/webm" />
             <source src="./static/bg-demo.mp4" type="video/mp4" />
           </video>


### PR DESCRIPTION
https://stackoverflow.com/questions/17994666/video-auto-play-is-not-working-in-safari-and-chrome-desktop-browser

Browsers won't autoplay videos that have been manipulated into the dom unless they are muted. I don't think this video needs sound so I added the `muted` property to get around that.

/cc @paulathevalley @kenwheeler @beccalee123 @coopy 