### PR TITLE
Task/sticky title bar

### DIFF
--- a/src/components/markdown.js
+++ b/src/components/markdown.js
@@ -97,6 +97,12 @@ export const Markdown = styled.article`
   & a {
     color: #895160;
 
+    &:target {
+      display: block;
+      position: relative;
+      top: -60px;
+      visibility: hidden;
+    }
     &:hover {
       color: black;
       text-decoration: underline;

--- a/src/components/navigation.js
+++ b/src/components/navigation.js
@@ -22,10 +22,10 @@ export const SidebarContainer = styled.div`
   width: 26rem;
   min-width: 26rem;
   min-height: 100vh;
+
   @media (max-width: 768px) {
     min-width: 5rem;
-    width: 5rem
-    };
+    width: 5rem;
   }
 `;
 

--- a/src/components/navigation.js
+++ b/src/components/navigation.js
@@ -16,8 +16,17 @@ export const Navigation = styled.div`
     }
   }
 `;
+export const SidebarContainer = styled.div`
+  width: 26rem;
+  min-width: 26rem;
+  min-height: 100vh;
+  @media (max-width: 768px) {
+    min-width: 5rem;
+    width: 5rem};
+  }
+`;
 
-export const SidebarContainer = styled.aside`
+export const SidebarWrapper = styled.aside`
   font-family: "akkurat";
   background-image: url("../../static/svgs/pink-sidebar-background.svg");
   background-repeat: repeat-y;
@@ -25,7 +34,8 @@ export const SidebarContainer = styled.aside`
   padding-top: 18rem;
   min-width: 26rem;
   width: 26rem;
-  position: ${props => (props.overlay ? "fixed" : "")};
+  z-index: 900;
+  position: fixed;
 
   @media (max-width: 768px) {
     background-image: ${props =>

--- a/src/components/navigation.js
+++ b/src/components/navigation.js
@@ -1,6 +1,8 @@
 import styled from "styled-components";
 import { Link } from "react-static";
 
+const sidebarZIndex = 900;
+
 export const Navigation = styled.div`
   align-items: center;
   background: rgba(0, 0, 0, 0.3);
@@ -34,7 +36,7 @@ export const SidebarWrapper = styled.aside`
   padding-top: 18rem;
   min-width: 26rem;
   width: 26rem;
-  z-index: 900;
+  z-index: ${sidebarZIndex};
   position: fixed;
 
   @media (max-width: 768px) {
@@ -44,6 +46,7 @@ export const SidebarWrapper = styled.aside`
         : 'url("../../static/svgs/collapsed-sidebar-background.svg")'};
     min-width: ${props => (props.overlay ? "26rem" : "5rem")};
     width: ${props => (props.overlay ? "26rem" : "5rem")};
+    padding-top: 6rem;
   }
 `;
 

--- a/src/components/navigation.js
+++ b/src/components/navigation.js
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 import { Link } from "react-static";
 
-const sidebarZIndex = 900;
+const sidebarZIndex = 800;
 
 export const Navigation = styled.div`
   align-items: center;

--- a/src/components/navigation.js
+++ b/src/components/navigation.js
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 import { Link } from "react-static";
 
-const sidebarZIndex = 800;
+const sidebarZIndex = 900;
 
 export const Navigation = styled.div`
   align-items: center;
@@ -24,7 +24,8 @@ export const SidebarContainer = styled.div`
   min-height: 100vh;
   @media (max-width: 768px) {
     min-width: 5rem;
-    width: 5rem};
+    width: 5rem
+    };
   }
 `;
 
@@ -46,7 +47,6 @@ export const SidebarWrapper = styled.aside`
         : 'url("../../static/svgs/collapsed-sidebar-background.svg")'};
     min-width: ${props => (props.overlay ? "26rem" : "5rem")};
     width: ${props => (props.overlay ? "26rem" : "5rem")};
-    padding-top: 6rem;
   }
 `;
 

--- a/src/screens/docs/article.js
+++ b/src/screens/docs/article.js
@@ -15,21 +15,15 @@ import yaml from "prismjs/components/prism-yaml";
 const Container = styled.div`
   max-width: 80rem;
   min-height: 100vh;
-  padding: 2rem 4rem 8rem;
   width: 100%;
-`;
-
-const DocsTitle = styled.h2`
-  font-size: 3.5rem;
-  flex: auto;
-  line-height: 1.3;
-  width: 100%;
-  letter-spacing: 0.5rem;
-
-  @media (max-width: 768px) {
-    font-size: 3rem;
-    margin: 0;
-  }
+  padding: 10rem 4rem 8rem;
+}
+@media (max-width: 768px) {
+  padding: 6rem 4rem 8rem 4rem;
+}
+@media (max-width: 600px) {
+  padding: 4rem 4rem 8rem 0.3rem;
+}
 `;
 
 class Article extends React.Component {
@@ -44,7 +38,6 @@ class Article extends React.Component {
   render() {
     return (
       <Container>
-        <DocsTitle>SPECTACLE</DocsTitle>
         <Markdown dangerouslySetInnerHTML={{ __html: this.props.renderedMd }} />
       </Container>
     );

--- a/src/screens/docs/article.js
+++ b/src/screens/docs/article.js
@@ -19,7 +19,7 @@ const Container = styled.div`
   padding: 10rem 4rem 8rem;
 }
 @media (max-width: 768px) {
-  padding: 6rem 4rem 8rem 4rem;
+  padding: 6rem 4rem 8rem 3.5rem;
 }
 @media (max-width: 600px) {
   padding: 4rem 4rem 8rem 0.3rem;

--- a/src/screens/docs/index.js
+++ b/src/screens/docs/index.js
@@ -5,7 +5,7 @@ import { withRouter, withRouteData } from "react-static";
 import Article from "./article";
 import Sidebar from "./sidebar";
 
-const headerZIndex = 900;
+const headerZIndex = 800;
 
 const Container = styled.div`
   display: flex;

--- a/src/screens/docs/index.js
+++ b/src/screens/docs/index.js
@@ -37,9 +37,9 @@ const Wrapper = styled.div`
 `;
 
 const HeaderLogo = styled.img`
-  position: absolute;
+  position: relative;
   right: 25rem;
-  top: 1.2rem;
+
   @media (max-width: 768px) {
     right: 7rem;
     padding-left: 2rem;

--- a/src/screens/docs/index.js
+++ b/src/screens/docs/index.js
@@ -25,15 +25,15 @@ const Wrapper = styled.div`
   z-index: ${headerZIndex};
   padding-right: 3rem;
   box-shadow: 0 5px 10px -5px lightgrey;
-}
-@media (max-width: 768px) {
-  box-shadow: 0 5px 10px -5px lightgrey;
-  margin-left: 2.5rem;
-  right: 0;
-  width: calc(100% - 2rem);
-  justify-content: flex-start;
-  left: 0;
-}
+
+  @media (max-width: 768px) {
+    box-shadow: 0 5px 10px -5px lightgrey;
+    margin-left: 2.5rem;
+    right: 0;
+    width: calc(100% - 2rem);
+    justify-content: flex-start;
+    left: 0;
+  }
 `;
 
 const HeaderLogo = styled.img`
@@ -53,6 +53,7 @@ const CollapsedMenu = styled.div`
   cursor: pointer;
   padding-left: 3rem;
   display: none;
+
   @media (max-width: 768px) {
     display: block;
     visibility: ${props => (props.overlay ? "hidden" : "visible")};

--- a/src/screens/docs/index.js
+++ b/src/screens/docs/index.js
@@ -5,7 +5,7 @@ import { withRouter, withRouteData } from "react-static";
 import Article from "./article";
 import Sidebar from "./sidebar";
 
-const headerZIndex = 1000;
+const headerZIndex = 900;
 
 const Container = styled.div`
   display: flex;

--- a/src/screens/docs/index.js
+++ b/src/screens/docs/index.js
@@ -17,24 +17,31 @@ const Wrapper = styled.div`
   flex-direction: row;
   height: 6rem;
   width: 100%;
-  position: absolute;
+  position: fixed;
+  left: 21rem;
+  background: white;
+  z-index: 1000;
   padding-right: 3rem;
+  box-shadow: 0 5px 10px -5px lightgrey;
 }
-
 @media (max-width: 768px) {
   box-shadow: 0 5px 10px -5px lightgrey;
-  margin-left: 3rem;
+  margin-left: 2.5rem;
   right: 0;
   width: calc(100% - 2rem);
-  justify-content: flex-end;
+  justify-content: flex-start;
+  left: 0;
 }
 `;
 
 const HeaderLogo = styled.img`
   position: absolute;
-  right: 3rem;
-  top: 1.5rem;
-
+  right: 25rem;
+  top: 1.2rem;
+  @media (max-width: 768px) {
+    right: 7rem;
+    padding-left: 2rem;
+  }
   @media (max-width: 600px) {
     display: none;
   }
@@ -43,13 +50,32 @@ const HeaderLogo = styled.img`
 const CollapsedMenu = styled.div`
   padding-left: 3rem;
   display: ${props => (props.overlay ? "none" : "")};
-
   @media (min-width: 768px) {
     display: none;
   }
   @media (max-width: 600px) {
+    padding-left: 2.5rem;
     position: absolute;
     left: 0;
+  }
+`;
+
+const DocsTitle = styled.h2`
+  font-size: 3rem;
+  top: 0.2rem;
+  flex: auto;
+  width: 100%;
+  letter-spacing: 0.5rem;
+  margin: 0;
+  position: relative;
+  left: 9rem;
+  @media (max-width: 768px) {
+    font-size: 3rem;
+    left: 2rem;
+    margin: 0;
+  }
+  @media (max-width: 600px) {
+    left: 6.5rem;
   }
 `;
 
@@ -79,6 +105,7 @@ class Docs extends React.Component {
               onClick={() => this.openSidebar()}
             />
           </CollapsedMenu>
+          <DocsTitle>SPECTACLE</DocsTitle>
           <HeaderLogo
             src="../../static/svgs/logo_formidable_dark.svg"
             alt="Formidable Logo"

--- a/src/screens/docs/index.js
+++ b/src/screens/docs/index.js
@@ -5,6 +5,8 @@ import { withRouter, withRouteData } from "react-static";
 import Article from "./article";
 import Sidebar from "./sidebar";
 
+const headerZIndex = 1000;
+
 const Container = styled.div`
   display: flex;
   flex-direction: row;
@@ -20,7 +22,7 @@ const Wrapper = styled.div`
   position: fixed;
   left: 21rem;
   background: white;
-  z-index: 1000;
+  z-index: ${headerZIndex};
   padding-right: 3rem;
   box-shadow: 0 5px 10px -5px lightgrey;
 }
@@ -49,9 +51,10 @@ const HeaderLogo = styled.img`
 
 const CollapsedMenu = styled.div`
   padding-left: 3rem;
-  display: ${props => (props.overlay ? "none" : "")};
-  @media (min-width: 768px) {
-    display: none;
+  display: none;
+  @media (max-width: 768px) {
+    display: block;
+    visibility: ${props => (props.overlay ? "hidden" : "visible")};
   }
   @media (max-width: 600px) {
     padding-left: 2.5rem;

--- a/src/screens/docs/index.js
+++ b/src/screens/docs/index.js
@@ -50,6 +50,7 @@ const HeaderLogo = styled.img`
 `;
 
 const CollapsedMenu = styled.div`
+  cursor: pointer;
   padding-left: 3rem;
   display: none;
   @media (max-width: 768px) {

--- a/src/screens/docs/sidebar.js
+++ b/src/screens/docs/sidebar.js
@@ -5,7 +5,8 @@ import { withRouteData, withRouter, Link } from "react-static";
 import {
   SidebarNavItem,
   SidebarNavSubItem,
-  SidebarContainer
+  SidebarContainer,
+  SidebarWrapper
 } from "../../components/navigation";
 
 const HeroLogo = styled.img`
@@ -82,48 +83,50 @@ class Sidebar extends React.Component {
   render() {
     const { sidebarHeaders, overlay, closeSidebar } = this.props;
     return (
-      <SidebarContainer overlay={overlay}>
-        <CloseButton
-          src="../../static/svgs/x.svg"
-          alt="X"
-          overlay={overlay}
-          onClick={() => closeSidebar()}
-        />
-        <Link to={"/"}>
-          <HeroLogo
-            src="../../static/svgs/logo-sidebar.svg"
-            alt="Formidable Logo"
+      <SidebarContainer>
+        <SidebarWrapper overlay={overlay}>
+          <CloseButton
+            src="../../static/svgs/x.svg"
+            alt="X"
             overlay={overlay}
+            onClick={() => closeSidebar()}
           />
-        </Link>
-        <ContentWrapper>
-          <SidebarNavItem to={`/#`} replace key={"home"}>
-            Home
-          </SidebarNavItem>
-          <SidebarNavItem
-            to={`/docs/getting-started`}
-            replace
-            key={"documentation"}
-          >
-            Documentation
-          </SidebarNavItem>
-          {sidebarHeaders &&
-            sidebarHeaders.map(sh => this.renderSidebarItem(sh))}
-          <SidebarNavItem
-            to={"https://www.github.com/FormidableLabs/spectacle/issues"}
-            replace
-            key={"issues"}
-          >
-            Issues
-          </SidebarNavItem>
-          <SidebarNavItem
-            to={"https://github.com/FormidableLabs/spectacle"}
-            replace
-            key={"github"}
-          >
-            Github
-          </SidebarNavItem>
-        </ContentWrapper>
+          <Link to={"/"}>
+            <HeroLogo
+              src="../../static/svgs/logo-sidebar.svg"
+              alt="Formidable Logo"
+              overlay={overlay}
+            />
+          </Link>
+          <ContentWrapper>
+            <SidebarNavItem to={`/#`} replace key={"home"}>
+              Home
+            </SidebarNavItem>
+            <SidebarNavItem
+              to={`/docs/getting-started`}
+              replace
+              key={"documentation"}
+            >
+              Documentation
+            </SidebarNavItem>
+            {sidebarHeaders &&
+              sidebarHeaders.map(sh => this.renderSidebarItem(sh))}
+            <SidebarNavItem
+              to={"https://www.github.com/FormidableLabs/spectacle/issues"}
+              replace
+              key={"issues"}
+            >
+              Issues
+            </SidebarNavItem>
+            <SidebarNavItem
+              to={"https://github.com/FormidableLabs/spectacle"}
+              replace
+              key={"github"}
+            >
+              Github
+            </SidebarNavItem>
+          </ContentWrapper>
+        </SidebarWrapper>
       </SidebarContainer>
     );
   }

--- a/src/screens/docs/sidebar.js
+++ b/src/screens/docs/sidebar.js
@@ -17,7 +17,6 @@ const HeroLogo = styled.img`
 
   @media (max-width: 768px) {
     display: ${props => (props.overlay ? "" : "none")};
-    position: relative;
   }
 `;
 
@@ -52,7 +51,6 @@ const CloseButton = styled.img`
   display: none;
 
   @media (max-width: 768px) {
-    top: 7rem;
     display: ${props => (props.overlay ? "block" : "none")};
   }
 `;

--- a/src/screens/docs/sidebar.js
+++ b/src/screens/docs/sidebar.js
@@ -27,6 +27,10 @@ const ContentWrapper = styled.div`
   margin-bottom: 1rem;
   margin-top: 4rem;
   height: auto;
+
+  @media (max-width: 768px) {
+    display: ${props => (props.overlay ? "" : "none")};
+  }
 `;
 
 const SubContentWrapper = styled.div`
@@ -41,12 +45,15 @@ const Wrapper = styled.div`
 `;
 
 const CloseButton = styled.img`
+  cursor: pointer;
   top: 1rem;
   right: 7rem;
   position: absolute;
-  display: ${props => (props.overlay ? "" : "none")};
+  display: none;
+
   @media (max-width: 768px) {
     top: 7rem;
+    display: ${props => (props.overlay ? "block" : "none")};
   }
 `;
 
@@ -102,7 +109,7 @@ class Sidebar extends React.Component {
               overlay={overlay}
             />
           </Link>
-          <ContentWrapper>
+          <ContentWrapper overlay={overlay}>
             <SidebarNavItem to={`/#`} replace key={"home"}>
               Home
             </SidebarNavItem>

--- a/src/screens/docs/sidebar.js
+++ b/src/screens/docs/sidebar.js
@@ -11,12 +11,13 @@ import {
 
 const HeroLogo = styled.img`
   position: absolute;
-  top: 2rem;
+  top: 3rem;
   left: 4rem;
   min-width: 14rem;
 
   @media (max-width: 768px) {
     display: ${props => (props.overlay ? "" : "none")};
+    position: relative;
   }
 `;
 
@@ -24,7 +25,7 @@ const ContentWrapper = styled.div`
   display: flex;
   flex-direction: column;
   margin-bottom: 1rem;
-  margin-top: 1rem;
+  margin-top: 4rem;
   height: auto;
 `;
 
@@ -40,10 +41,13 @@ const Wrapper = styled.div`
 `;
 
 const CloseButton = styled.img`
-  top: 2rem;
+  top: 1rem;
   right: 7rem;
   position: absolute;
   display: ${props => (props.overlay ? "" : "none")};
+  @media (max-width: 768px) {
+    top: 7rem;
+  }
 `;
 
 class Sidebar extends React.Component {

--- a/src/screens/home/hero.js
+++ b/src/screens/home/hero.js
@@ -86,7 +86,6 @@ const HeroCopyLink = styled.p`
 `;
 
 const HeroCopyText = styled.span`
-  font-family: "tiempos";
   padding: 0 1.6rem;
   text-align: left;
   min-width: 20rem;

--- a/src/screens/home/hero.js
+++ b/src/screens/home/hero.js
@@ -86,6 +86,7 @@ const HeroCopyLink = styled.p`
 `;
 
 const HeroCopyText = styled.span`
+  font-family: "tiempos";
   padding: 0 1.6rem;
   text-align: left;
   min-width: 20rem;


### PR DESCRIPTION
Fixed #61
Moved `DocsTitle` element to the header wrapper in Docs component.
Positioned the header fixed to create sticky bar.
Styled sidebar to adjust to the header's position fixed.
Set the  `CloseButton` to hide when the desktop screen size gets activated (>768px).
Fixed the target of the anchor tags for sidebar nav navigation to avoid article topics being hidden under the header.
Fixed the `CloseButton` positioning as it would set under the Spectacle logo image causing redirection to the home page instead of closing the menu.


