### PR TITLE
fix build and styling

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "extends": "react-static/.babelrc"
+  "extends": "react-static/.babelrc",
+  "plugins": ["babel-plugin-styled-components"]
 }

--- a/src/screens/docs/sidebar.js
+++ b/src/screens/docs/sidebar.js
@@ -48,7 +48,10 @@ const CloseButton = styled.img`
 class Sidebar extends React.Component {
   renderSidebarItem(item) {
     const { tocArray } = this.props;
-    const currentPath = `/docs${item.path}` === window.location.pathname;
+    let currentPath;
+    if (typeof window !== "undefined") {
+      currentPath = `/docs${item.path}` === window.location.pathname;
+    }
     const subContent = tocArray.filter(toc => toc.level === 2);
 
     return (

--- a/static.config.js
+++ b/static.config.js
@@ -1,7 +1,9 @@
+import React from "react";
 import { reloadRoutes } from "react-static/node";
 import chokidar from "chokidar";
 import { getSidebarItems } from "./static-config-helpers/md-data-transforms";
 const staticWebpackConfig = require("./static-config-parts/static-webpack-config");
+const { ServerStyleSheet } = require("styled-components");
 
 chokidar.watch("content").on("all", () => reloadRoutes());
 
@@ -59,6 +61,21 @@ export default {
       // { path: "/404", component: "src/screens/404" }
     ];
   },
-  webpack: staticWebpackConfig,
-  Document: require("./static-config-parts/document").default
+  renderToHtml: (render, Comp, meta) => {
+    const sheet = new ServerStyleSheet();
+    const html = render(sheet.collectStyles(<Comp />));
+    // see https://github.com/nozzle/react-static/blob/v5/docs/config.md#rendertohtml
+    // you can stick whatever you want here, but it's mutable at build-time, not dynamic
+    // at run-time -- key difference!
+
+    meta.styleTags = sheet.getStyleElement();
+    return html;
+  },
+  // So this is kinda cutesy, it's the equivalent of html.js in gatsby, it defines
+  // the root html page as a react component:
+  // https://github.com/nozzle/react-static/blob/master/docs/config.md#document
+  Document: require("./static-config-parts/document").default,
+  // turn this on if it helps your local development workflow for build testing
+  bundleAnalyzer: false,
+  webpack: staticWebpackConfig
 };


### PR DESCRIPTION
@DDunc quick build fix. Grabs the `renderToHtml` work around you were using in `victory-docs` rewrite. With this change I'm on longer seeing style issues in the prob build. Let me know if you are.