### PR TITLE
Bug/mobile padding

### DIFF
--- a/src/components/markdown.js
+++ b/src/components/markdown.js
@@ -95,7 +95,7 @@ export const Markdown = styled.article`
     font-family: "tiempos";
     font-size: 1.6rem;
     padding: 0.5rem;
-    @media (max-width: 600px) {
+    @media (max-width: 768px) {
       margin-left: -2rem;
     }
   }

--- a/src/components/markdown.js
+++ b/src/components/markdown.js
@@ -2,6 +2,9 @@ import styled from "styled-components";
 
 export const Markdown = styled.article`
   width: 60vw;
+  @media (max-width: 768px) {
+    width: 75vw;
+  }
   & h1 {
     font-family: "sharp";
     font-size: 3.4rem;
@@ -92,6 +95,9 @@ export const Markdown = styled.article`
     font-family: "tiempos";
     font-size: 1.6rem;
     padding: 0.5rem;
+    @media (max-width: 600px) {
+      margin-left: -2rem;
+    }
   }
 
   & a {

--- a/src/components/section-title.js
+++ b/src/components/section-title.js
@@ -9,4 +9,7 @@ export const SectionTitle = styled.h2`
   @media (min-width: 768px) {
     margin: 0 0 6rem;
   }
+  @media (max-width: 768px) {
+    margin: 2rem 0;
+  }
 `;

--- a/src/components/wrapper.js
+++ b/src/components/wrapper.js
@@ -15,4 +15,7 @@ export const Wrapper = styled.div`
     max-width: 116rem;
     padding: ${props => (props.noPadding ? "0 8rem" : "8rem")}
   }
+  @media (max-width: 768px) {
+    width: 90%;
+  }
 `;

--- a/src/content/docs/getting-started.md
+++ b/src/content/docs/getting-started.md
@@ -69,66 +69,66 @@ We can start with this project's sample at [`one-page.html`](./one-page.html). I
 
 2.  The presentation must include exactly **one** script tag with the type `text/spectacle` that is a function. Presently, that function is directly inserted inline into a wrapper code boilerplate as a React Component `render` function. The wrapper is transpiled. There should not be any extraneous content around it like outer variables or comments.
 
-    **Good** examples:
+**Good** examples:
 
-    ```html
-    <script type="text/spectacle">
-      () => (
-        <Deck>{/* SLIDES */}</Deck>
-      )
-    </script>
-    ```
+```html
+<script type="text/spectacle">
+  () => (
+    <Deck>{/* SLIDES */}</Deck>
+  )
+</script>
+```
 
-    ```html
-    <script type="text/spectacle">
-      () => {
-        // Code-y code stuff in JS...
+```html
+<script type="text/spectacle">
+  () => {
+    // Code-y code stuff in JS...
 
-        return (
-          <Deck>{/* SLIDES */}</Deck>
-        );
-      }
-    </script>
-    ```
+    return (
+      <Deck>{/* SLIDES */}</Deck>
+    );
+  }
+</script>
+```
 
-    **Bad** examples of what not to do:
+**Bad** examples of what not to do:
 
-    ```html
-    <script type="text/spectacle">
-      // Outer comment (BAD)
-      const outerVariable = "BAD";
+```html
+<script type="text/spectacle">
+  // Outer comment (BAD)
+  const outerVariable = "BAD";
 
-      () => (
-        <Deck>{/* SLIDES */}</Deck>
-      )
-    </script>
-    ```
+  () => (
+    <Deck>{/* SLIDES */}</Deck>
+  )
+</script>
+```
 
 3.  If you want to create your own theme settings, you can use the following code snippet to change the [themes](#createthemecolors-fonts) default settings.
 
-    ```html
-    <script type="text/spectacle">
-      () => {
-        const { themes: { defaultTheme } } = Spectacle;
-        const theme = defaultTheme({
-          // Change default settings
-          primary: "blue",
-          secondary: "red"
-        },
-        {
-          primary: "Helvetica",
-        });
+```html
+<script type="text/spectacle">
+  () => {
+    const { themes: { defaultTheme } } = Spectacle;
+    const theme = defaultTheme({
+      // Change default settings
+      primary: "blue",
+      secondary: "red"
+    },
+    {
+      primary: "Helvetica",
+    });
 
-        return (
-          <Deck transition={['zoom']} theme={theme}>
-            <Slide>some stuff</Slide>
-            <Slide>other stuff</Slide>
-            <Slide>some more stuff</Slide>
-          </Deck>
-        );
-      }
-    </script>
-    ```
+    return (
+      <Deck transition={['zoom']} theme={theme}>
+        <Slide>some stuff</Slide>
+        <Slide>other stuff</Slide>
+        <Slide>some more stuff</Slide>
+      </Deck>
+    );
+  }
+</script>
+```
 
 ... with those guidelines in mind, here's the boilerplate that you can copy-and-paste into an HTML file and start a Spectacle presentation that works from the get go!
 

--- a/src/screens/docs/article.js
+++ b/src/screens/docs/article.js
@@ -13,7 +13,7 @@ const Container = styled.div`
     padding: 6rem 4rem 8rem 3.5rem;
   }
   .gatsby-highlight {
-    @media (max-width: 600px) {
+    @media (max-width: 768px) {
       margin-left: -2rem;
     }
     code {

--- a/src/screens/docs/article.js
+++ b/src/screens/docs/article.js
@@ -9,13 +9,17 @@ const Container = styled.div`
   min-height: 100vh;
   width: 100%;
   padding: 10rem 4rem 8rem;
-}
-@media (max-width: 768px) {
-  padding: 6rem 4rem 8rem 3.5rem;
-}
-@media (max-width: 600px) {
-  padding: 4rem 4rem 8rem 0.3rem;
-}
+  @media (max-width: 768px) {
+    padding: 6rem 4rem 8rem 3.5rem;
+  }
+  .gatsby-highlight {
+    @media (max-width: 600px) {
+      margin-left: -2rem;
+    }
+    code {
+      overflow-x: scroll;
+    }
+  }
 `;
 
 class Article extends React.Component {

--- a/src/screens/docs/index.js
+++ b/src/screens/docs/index.js
@@ -54,7 +54,7 @@ const HeaderLogo = styled.img`
 
 const CollapsedMenu = styled.div`
   cursor: pointer;
-  padding-left: 3rem;
+  padding-left: 4rem;
   display: none;
 
   @media (max-width: 768px) {
@@ -62,7 +62,7 @@ const CollapsedMenu = styled.div`
     visibility: ${props => (props.overlay ? "hidden" : "visible")};
   }
   @media (max-width: 600px) {
-    padding-left: 2.5rem;
+    padding-left: 3.5rem;
     position: absolute;
     left: 0;
   }

--- a/src/screens/home/preview.js
+++ b/src/screens/home/preview.js
@@ -9,6 +9,13 @@ const OuterWrapper = styled.div`
   background: #f3f3f3;
 `;
 
+const Video = styled.video`
+  width: 100%;
+  @media (max-width: 768px) {
+    margin: 0 0 2rem 0;
+  }
+`;
+
 class Preview extends React.Component {
   render() {
     const { previewObj } = this.props;
@@ -18,16 +25,10 @@ class Preview extends React.Component {
         <Wrapper>
           <SectionTitle>Code Preview</SectionTitle>
           <BodyCopy>{previewObj.description}</BodyCopy>
-          <video
-            width="100%"
-            autoPlay
-            muted
-            loop
-            poster="./static/bg-still.png"
-          >
+          <Video autoPlay muted loop poster="./static/bg-still.png">
             <source src="./static/bg-demo.webm" type="video/webm" />
             <source src="./static/bg-demo.mp4" type="video/mp4" />
-          </video>
+          </Video>
         </Wrapper>
       </OuterWrapper>
     );


### PR DESCRIPTION
This PR fixes styles on mobile sizes:

<img width="400" alt="Screen Shot 2019-04-01 at 5 37 09 PM" src="https://user-images.githubusercontent.com/3719995/55368107-0020d700-54a5-11e9-8a62-2b4fd5fab0c7.png">

<img width="398" alt="Screen Shot 2019-04-01 at 5 37 25 PM" src="https://user-images.githubusercontent.com/3719995/55368110-02833100-54a5-11e9-9ab0-556b49fc6435.png">
